### PR TITLE
Remove node + npm from build (PHP 5.5)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,6 @@ RUN requirements="libpng12-dev libmcrypt-dev libmcrypt4 libcurl3-dev libfreetype
     && requirementsToRemove="libpng12-dev libmcrypt-dev libcurl3-dev libpng12-dev libfreetype6-dev libjpeg62-turbo-dev" \
     && apt-get purge --auto-remove -y $requirementsToRemove
 
-# Install Node v4 with latest NPM
-RUN curl -sL https://deb.nodesource.com/setup_4.x | bash - && \
-    apt-get install -y nodejs && \
-    npm install -g npm
-
 RUN usermod -u 1000 www-data
 RUN a2enmod rewrite
 RUN sed -i -e 's/\/var\/www\/html/\/var\/www\/htdocs/' /etc/apache2/apache2.conf


### PR DESCRIPTION
Not actually used by Magento, just something I mistakenly left in the Dockerfile.
